### PR TITLE
Playlists in subfolders

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+-e .
 ipdb==0.12.2
 flake8==3.7.9
 mypy==0.740

--- a/tests/fixtures/collection.nml
+++ b/tests/fixtures/collection.nml
@@ -16,3 +16,4 @@
     </ENTRY>
   </COLLECTION>
 </NML>
+

--- a/tests/fixtures/collection.nml
+++ b/tests/fixtures/collection.nml
@@ -16,4 +16,3 @@
     </ENTRY>
   </COLLECTION>
 </NML>
-

--- a/tests/fixtures/playlist.nml
+++ b/tests/fixtures/playlist.nml
@@ -11,6 +11,28 @@
             </ENTRY>
           </PLAYLIST>
         </NODE>
+        <NODE TYPE="FOLDER" NAME="Foo">
+          <SUBNODES COUNT="2">
+            <NODE TYPE="PLAYLIST" NAME="Preparation2">
+              <PLAYLIST ENTRIES="212" TYPE="LIST" UUID="f80b2bdebbb843eb897c1ae90af896f5">
+                <ENTRY>
+                  <PRIMARYKEY TYPE="TRACK" KEY="osx/:Users/:johndoe/:Music/:pechundschwefel/:549043_The_Sky_Was_Pink_Icelandic_Version.mp3"/>
+                </ENTRY>
+              </PLAYLIST>
+            </NODE>
+            <NODE TYPE="FOLDER" NAME="Bar">
+              <SUBNODES COUNT="1">
+                <NODE TYPE="PLAYLIST" NAME="Preparation3">
+                  <PLAYLIST ENTRIES="212" TYPE="LIST" UUID="f80b2bdebbb843eb897c1ae90af896f5">
+                    <ENTRY>
+                      <PRIMARYKEY TYPE="TRACK" KEY="osx/:Users/:johndoe/:Music/:pechundschwefel/:549043_The_Sky_Was_Pink_Icelandic_Version.mp3"/>
+                    </ENTRY>
+                  </PLAYLIST>
+                </NODE>
+              </SUBNODES>
+            </NODE>
+          </SUBNODES>
+        </NODE>
       </SUBNODES>
     </NODE>
   </PLAYLISTS>

--- a/tests/fixtures/playlist.nml
+++ b/tests/fixtures/playlist.nml
@@ -14,7 +14,7 @@
         <NODE TYPE="FOLDER" NAME="Foo">
           <SUBNODES COUNT="2">
             <NODE TYPE="PLAYLIST" NAME="Preparation2">
-              <PLAYLIST ENTRIES="212" TYPE="LIST" UUID="f80b2bdebbb843eb897c1ae90af896f5">
+              <PLAYLIST ENTRIES="212" TYPE="LIST" UUID="f80b2bdebbb843eb897c1ae90af896f6">
                 <ENTRY>
                   <PRIMARYKEY TYPE="TRACK" KEY="osx/:Users/:johndoe/:Music/:pechundschwefel/:549043_The_Sky_Was_Pink_Icelandic_Version.mp3"/>
                 </ENTRY>
@@ -23,7 +23,7 @@
             <NODE TYPE="FOLDER" NAME="Bar">
               <SUBNODES COUNT="1">
                 <NODE TYPE="PLAYLIST" NAME="Preparation3">
-                  <PLAYLIST ENTRIES="212" TYPE="LIST" UUID="f80b2bdebbb843eb897c1ae90af896f5">
+                  <PLAYLIST ENTRIES="212" TYPE="LIST" UUID="f80b2bdebbb843eb897c1ae90af896f7">
                     <ENTRY>
                       <PRIMARYKEY TYPE="TRACK" KEY="osx/:Users/:johndoe/:Music/:pechundschwefel/:549043_The_Sky_Was_Pink_Icelandic_Version.mp3"/>
                     </ENTRY>

--- a/tests/fixtures/playlist.nml
+++ b/tests/fixtures/playlist.nml
@@ -37,3 +37,4 @@
     </NODE>
   </PLAYLISTS>
 </NML>
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,8 +28,15 @@ def test_collection(nml_file):
 def test_playlists(nml_file):
     collection = TraktorCollection(nml_file)
     assert collection.playlists
+    assert len(collection.playlists) == 3
     playlist = collection.playlists[0]
     assert playlist.name == 'Preparation'
+    assert len(playlist.entries) == 1
+    playlist = collection.playlists[1]
+    assert playlist.name == 'Foo/Preparation2'
+    assert len(playlist.entries) == 1
+    playlist = collection.playlists[2]
+    assert playlist.name == 'Foo/Bar/Preparation3'
     assert len(playlist.entries) == 1
 
 

--- a/traktor_nml_utils/main.py
+++ b/traktor_nml_utils/main.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 from dataclasses import dataclass, field
-
 from lxml import etree
 from traktor_nml_utils.xmldataclass import XMLdataclass
 
@@ -12,9 +11,7 @@ FOLDER_XPATH = "./SUBNODES/NODE[@TYPE='FOLDER']"
 PLAYLIST_XPATH = "./SUBNODES/NODE[@TYPE='PLAYLIST']"
 ENTRY_XPATH = "/COLLECTION/ENTRY"
 
-PLAYLIST_ENTRY_XPATH = (
-    "./ENTRY"
-)
+PLAYLIST_ENTRY_XPATH = "./ENTRY"
 
 HISTORY_XPATH = (
     "/PLAYLISTS/NODE[@TYPE='FOLDER']"
@@ -34,23 +31,25 @@ class Playlist(XMLdataclass):
 
     @property
     def entries(self):
-        return [PlaylistEntry(entry, self.xmlfile)
-                for entry in self.xmltree.findall('PLAYLIST/ENTRY')]
+        return [
+            PlaylistEntry(entry, self.xmlfile)
+            for entry in self.xmltree.findall("PLAYLIST/ENTRY")
+        ]
 
 
 @dataclass(init=False)
 class PlaylistEntry(XMLdataclass):
-    filename: str = field(metadata={'xpath': 'PRIMARYKEY/@KEY'})
+    filename: str = field(metadata={"xpath": "PRIMARYKEY/@KEY"})
 
 
 @dataclass(init=False)
 class HistoryEntry(XMLdataclass):
-    deck: int = field(metadata={'xpath': 'EXTENDEDDATA/@DECK'})
-    duration: float = field(metadata={'xpath': 'EXTENDEDDATA/@DURATION'})
-    filename: str = field(metadata={'xpath': 'PRIMARYKEY/@KEY'})
-    played_public: bool = field(metadata={'xpath': 'EXTENDEDDATA/@PLAYEDPUBLIC'})
-    startdate: int = field(metadata={'xpath': 'EXTENDEDDATA/@STARTDATE'})
-    starttime: int = field(metadata={'xpath': 'EXTENDEDDATA/@STARTTIME'})
+    deck: int = field(metadata={"xpath": "EXTENDEDDATA/@DECK"})
+    duration: float = field(metadata={"xpath": "EXTENDEDDATA/@DURATION"})
+    filename: str = field(metadata={"xpath": "PRIMARYKEY/@KEY"})
+    played_public: bool = field(metadata={"xpath": "EXTENDEDDATA/@PLAYEDPUBLIC"})
+    startdate: int = field(metadata={"xpath": "EXTENDEDDATA/@STARTDATE"})
+    starttime: int = field(metadata={"xpath": "EXTENDEDDATA/@STARTTIME"})
 
     @property
     def startdatetime(self) -> datetime.datetime:
@@ -67,41 +66,44 @@ class HistoryEntry(XMLdataclass):
 
 @dataclass(init=False)
 class CollectionEntry(XMLdataclass):
-    artist: str = field(metadata={'xpath': '@ARTIST'})
-    album: str = field(metadata={'xpath': 'ALBUM/@TITLE'})
-    label: str = field(metadata={'xpath': 'INFO/@LABEL'})
-    audio_id: str = field(metadata={'xpath': '@AUDIO_ID'}, repr=False)
-    bitrate: int = field(metadata={'xpath': 'INFO/@BITRATE'})
-    bpm: float = field(metadata={'xpath': 'TEMPO/@BPM'})
-    key: str = field(metadata={'xpath': 'INFO/@KEY'})
-    comment: str = field(metadata={'xpath': 'INFO/@COMMENT'})
-    comment2: str = field(metadata={'xpath': 'INFO/@RATING'})
-    dir: str = field(metadata={'xpath': 'LOCATION/@DIR'})
-    file: str = field(metadata={'xpath': 'LOCATION/@FILE'})
-    filesize: str = field(metadata={'xpath': 'INFO/@FILESIZE'})
-    genre: str = field(metadata={'xpath': 'INFO/@GENRE'})
-    playcount: int = field(metadata={'xpath': 'INFO/@PLAYCOUNT'})
-    playtime: int = field(metadata={'xpath': 'INFO/@PLAYTIME'})
-    ranking: int = field(metadata={'xpath': 'INFO/@RANKING'})
-    title: str = field(metadata={'xpath': '@TITLE'})
-    import_date: str = field(metadata={'xpath': 'INFO/@IMPORT_DATE'})
-    release_date: str = field(metadata={'xpath': 'INFO@RELEASE_DATE'})
-    last_played: str = field(metadata={'xpath': 'INFO/@LAST_PLAYED'})
-    volume: str = field(metadata={'xpath': 'LOCATION/@VOLUME'})
+    artist: str = field(metadata={"xpath": "@ARTIST"})
+    album: str = field(metadata={"xpath": "ALBUM/@TITLE"})
+    label: str = field(metadata={"xpath": "INFO/@LABEL"})
+    audio_id: str = field(metadata={"xpath": "@AUDIO_ID"}, repr=False)
+    bitrate: int = field(metadata={"xpath": "INFO/@BITRATE"})
+    bpm: float = field(metadata={"xpath": "TEMPO/@BPM"})
+    key: str = field(metadata={"xpath": "INFO/@KEY"})
+    comment: str = field(metadata={"xpath": "INFO/@COMMENT"})
+    comment2: str = field(metadata={"xpath": "INFO/@RATING"})
+    dir: str = field(metadata={"xpath": "LOCATION/@DIR"})
+    file: str = field(metadata={"xpath": "LOCATION/@FILE"})
+    filesize: str = field(metadata={"xpath": "INFO/@FILESIZE"})
+    genre: str = field(metadata={"xpath": "INFO/@GENRE"})
+    playcount: int = field(metadata={"xpath": "INFO/@PLAYCOUNT"})
+    playtime: int = field(metadata={"xpath": "INFO/@PLAYTIME"})
+    ranking: int = field(metadata={"xpath": "INFO/@RANKING"})
+    title: str = field(metadata={"xpath": "@TITLE"})
+    import_date: str = field(metadata={"xpath": "INFO/@IMPORT_DATE"})
+    release_date: str = field(metadata={"xpath": "INFO@RELEASE_DATE"})
+    last_played: str = field(metadata={"xpath": "INFO/@LAST_PLAYED"})
+    volume: str = field(metadata={"xpath": "LOCATION/@VOLUME"})
 
     @property
     def cuepoints(self):
-        return [CuePoint(cuepoint, self.xmlfile) for cuepoint in self.xmltree.findall('CUE_V2')]
+        return [
+            CuePoint(cuepoint, self.xmlfile)
+            for cuepoint in self.xmltree.findall("CUE_V2")
+        ]
 
 
 @dataclass(init=False)
 class CuePoint(XMLdataclass):
-    name: str = field(metadata={'xpath': '@NAME'})
-    cuepoint_type: int = field(metadata={'xpath': '@TYPE'})
-    start: float = field(metadata={'xpath': '@START'})
-    length: float = field(metadata={'xpath': '@LEN'})
-    repeats: int = field(metadata={'xpath': '@REPEATS'})
-    hotcue: int = field(metadata={'xpath': '@HOTCUE'})
+    name: str = field(metadata={"xpath": "@NAME"})
+    cuepoint_type: int = field(metadata={"xpath": "@TYPE"})
+    start: float = field(metadata={"xpath": "@START"})
+    length: float = field(metadata={"xpath": "@LEN"})
+    repeats: int = field(metadata={"xpath": "@REPEATS"})
+    hotcue: int = field(metadata={"xpath": "@HOTCUE"})
 
 
 class TraktorCollection:
@@ -110,13 +112,15 @@ class TraktorCollection:
         self.xml_tree = etree.parse(self.path)
 
         self.entries = [
-            CollectionEntry(entry, path) for entry in self.xml_tree.findall(ENTRY_XPATH)]
+            CollectionEntry(entry, path) for entry in self.xml_tree.findall(ENTRY_XPATH)
+        ]
         self.playlists = self._get_playlists()
         self.history = [
-            HistoryEntry(entry, path) for entry in self.xml_tree.findall(HISTORY_XPATH)]
-    
+            HistoryEntry(entry, path) for entry in self.xml_tree.findall(HISTORY_XPATH)
+        ]
+
     def _get_playlists(self, parent=None, prefix=None):
-        #import pdb; pdb.set_trace()
+        # import pdb; pdb.set_trace()
         playlists = []
         if parent is None:
             parent = self.xml_tree.find(PLAYLIST_ROOT_XPATH)
@@ -131,10 +135,9 @@ class TraktorCollection:
         for playlist in parent.findall(PLAYLIST_XPATH):
             name_parts = []
             if prefix is not None:
-                name_parts.append(prefix) 
+                name_parts.append(prefix)
             name_parts.append(playlist.xpath("@NAME")[0])
             playlists.append(Playlist(playlist, self.path, "/".join(name_parts)))
         for folder in parent.findall(FOLDER_XPATH):
             playlists.extend(self._get_playlists(folder, prefix))
         return playlists
-

--- a/traktor_nml_utils/main.py
+++ b/traktor_nml_utils/main.py
@@ -120,7 +120,6 @@ class TraktorCollection:
         ]
 
     def _get_playlists(self, parent=None, prefix=None):
-        # import pdb; pdb.set_trace()
         playlists = []
         if parent is None:
             parent = self.xml_tree.find(PLAYLIST_ROOT_XPATH)


### PR DESCRIPTION
Adds support for playlists in folders rather than only playlists in the $ROOT folder.  Playlist paths are set in the format `FolderA/FolderB/PlaylistName`