### PR TITLE
Parse color

### DIFF
--- a/traktor_nml_utils/models/collection.py
+++ b/traktor_nml_utils/models/collection.py
@@ -319,6 +319,7 @@ class Infotype:
     :ivar rating:
     :ivar producer:
     :ivar mix:
+    :ivar color:
     """
     class Meta:
         name = "INFOType"
@@ -470,6 +471,13 @@ class Infotype:
         default=None,
         metadata=dict(
             name="MIX",
+            type="Attribute"
+        )
+    )
+    color: Optional[int] = field(
+        default=None,
+        metadata=dict(
+            name="COLOR",
             type="Attribute"
         )
     )

--- a/traktor_nml_utils/models/history.py
+++ b/traktor_nml_utils/models/history.py
@@ -220,6 +220,7 @@ class Infotype:
     :ivar key_lyrics:
     :ivar remixer:
     :ivar producer:
+    :ivar color:
     """
     class Meta:
         name = "INFOType"
@@ -350,6 +351,13 @@ class Infotype:
         default=None,
         metadata=dict(
             name="PRODUCER",
+            type="Attribute"
+        )
+    )
+    color: Optional[int] = field(
+        default=None,
+        metadata=dict(
+            name="COLOR",
             type="Attribute"
         )
     )

--- a/xml_to_xsd/collection.xsd
+++ b/xml_to_xsd/collection.xsd
@@ -50,6 +50,7 @@
         <xs:attribute type="xs:string" name="RATING" use="optional"/>
         <xs:attribute type="xs:string" name="PRODUCER" use="optional"/>
         <xs:attribute type="xs:string" name="MIX" use="optional"/>
+        <xs:attribute type="xs:byte" name="COLOR" use="optional"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>

--- a/xml_to_xsd/history.xsd
+++ b/xml_to_xsd/history.xsd
@@ -47,6 +47,7 @@
         <xs:attribute type="xs:string" name="LAST_PLAYED" use="optional"/>
         <xs:attribute type="xs:byte" name="FLAGS" use="optional"/>
         <xs:attribute type="xs:short" name="FILESIZE" use="optional"/>
+        <xs:attribute type="xs:byte" name="COLOR" use="optional"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>


### PR DESCRIPTION
This PR adds parsing for the track color.

It is an integer from 1 to 7 that refers to the color set by the user in Traktor. It's a useful visual cue for filtering.

I tested this PR against my own collection and it's working perfectly.