### PR TITLE
Use UTF-8 encoding to open files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.2.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name="traktor-nml-utils",
-    version="3.1.0",
+    version="3.2.0",
     description="Utilities to read and write Traktor NML files",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",

--- a/traktor_nml_utils/__init__.py
+++ b/traktor_nml_utils/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 from abc import ABC
 from pathlib import Path

--- a/traktor_nml_utils/__init__.py
+++ b/traktor_nml_utils/__init__.py
@@ -14,7 +14,7 @@ class ParseError(Exception):
 
 
 def is_history_file(path: Path):
-    content = open(path).read()
+    content = open(path, encoding="utf8").read()
     return "HistoryData" in content
 
 
@@ -26,7 +26,7 @@ class TraktorNmlMixin(ABC):
         self.nml = nml
 
     def save(self):
-        with self.path.open(mode="w") as file_obj:
+        with self.path.open(mode="w", encoding="utf8") as file_obj:
             serialized = XmlSerializer().render(self.nml)
             serialized = serialized.split("\n")
             serialized = "\n".join(line.lstrip() for line in serialized)


### PR DESCRIPTION
Got this error when running my script on Windows:

```
C:\Users\Axel\Documents\stemgen>python stemcopy.py collection.nml
Loading collection.nml...
Traceback (most recent call last):
  File "C:\Users\Axel\Documents\stemgen\stemcopy.py", line 35, in <module>
    collection = TraktorCollection(path=Path(args.collection))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Axel\AppData\Local\Programs\Python\Python311\Lib\site-packages\traktor_nml_utils\__init__.py", line 38, in __init__
    if is_history_file(path):
       ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Axel\AppData\Local\Programs\Python\Python311\Lib\site-packages\traktor_nml_utils\__init__.py", line 17, in is_history_file
    content = open(path).read()
              ^^^^^^^^^^^^^^^^^
  File "C:\Users\Axel\AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 10517645: character maps to <undefined>
```

It was running fine on macOS. After some digging I realized that it was probably because we didn't specify the encoding of the file. It's working fine on Windows now.